### PR TITLE
Add sticky registration CTA and update registration copy

### DIFF
--- a/index.vto
+++ b/index.vto
@@ -100,7 +100,7 @@ dates:
                         {{ /for }}
                     </ul>
                     <div class="mt-6">
-                        <a href="/register" class="inline-flex items-center gap-2 bg-white/30 hover:bg-white/40 text-white font-bold py-3 px-6 rounded-lg transition-colors duration-200">
+                        <a id="registration-open-cta" href="/register/" class="inline-flex items-center gap-2 bg-white/30 hover:bg-white/40 text-white font-bold py-3 px-6 rounded-lg transition-colors duration-200">
                             Påmelding er åpen! <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
                               <path fill-rule="evenodd" d="M2 8a.75.75 0 0 1 .75-.75h8.69L8.22 4.03a.75.75 0 0 1 1.06-1.06l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H2.75A.75.75 0 0 1 2 8Z" clip-rule="evenodd" />
                             </svg>
@@ -177,6 +177,50 @@ dates:
         </div>-->
     </div>
 </div>
+<div
+    id="registration-sticky-banner"
+    class="fixed inset-x-0 bottom-0 z-50 translate-y-full border-t border-white/20 bg-[#0E2E58] px-4 py-3 text-white shadow-2xl transition-transform duration-300 ease-out md:py-4"
+    aria-hidden="true"
+>
+    <div class="mx-auto flex max-w-6xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+            <p class="text-sm font-semibold uppercase tracking-wide text-[#46B3D9]">Påmelding 2026</p>
+            <p class="text-base font-bold md:text-lg">Påmeldingen er åpen. Sikre plass på Filtvet Feriekoloni.</p>
+        </div>
+        <a href="/register/" class="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-5 py-3 font-bold text-[#0E2E58] transition-colors duration-200 hover:bg-slate-100">
+            Meld på nå
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                <path fill-rule="evenodd" d="M2 8a.75.75 0 0 1 .75-.75h8.69L8.22 4.03a.75.75 0 0 1 1.06-1.06l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H2.75A.75.75 0 0 1 2 8Z" clip-rule="evenodd" />
+            </svg>
+        </a>
+    </div>
+</div>
+<script>
+    (function() {
+        const targetDate = new Date('{{ openForRegistrationAt }}');
+        const sourceCta = document.getElementById('registration-open-cta');
+        const stickyBanner = document.getElementById('registration-sticky-banner');
+
+        if (!sourceCta || !stickyBanner) {
+            return;
+        }
+
+        function setStickyBannerVisibility() {
+            const registrationIsOpen = new Date() >= targetDate;
+            const sourceCtaHasPassed = sourceCta.getBoundingClientRect().bottom < 0;
+            const shouldShow = registrationIsOpen && sourceCtaHasPassed;
+
+            stickyBanner.classList.toggle('translate-y-full', !shouldShow);
+            stickyBanner.classList.toggle('translate-y-0', shouldShow);
+            stickyBanner.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+        }
+
+        setStickyBannerVisibility();
+        window.addEventListener('scroll', setStickyBannerVisibility, { passive: true });
+        window.addEventListener('resize', setStickyBannerVisibility);
+        setInterval(setStickyBannerVisibility, 60000);
+    })();
+</script>
 <div class="py-24 sm:py-32">
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
         <div class="grid grid-cols-1 items-center gap-x-8 gap-y-16 lg:grid-cols-2">

--- a/index.vto
+++ b/index.vto
@@ -83,8 +83,8 @@ dates:
 
                 <!-- Dates Container (hidden initially) -->
                 <div id="dates-container" class="hidden">
-                    <div class="mb-6">
-                        <p class="text-sm opacity-90 text-balance">God jul og velkommen til påmelding! 🎄</p>
+                    <div class="mb-5 rounded-lg bg-[#FDE68A] p-3 text-sm text-[#0E2E58]">
+                        <p>Fristen for sommeren 2026 er passert. Søknader vurderes ved ledige plasser.</p>
                     </div>
                     <ul class="text-base md:text-lg space-y-3 text-left">
                         {{ for date of dates }}
@@ -185,7 +185,7 @@ dates:
     <div class="mx-auto flex max-w-6xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
             <p class="text-sm font-semibold uppercase tracking-wide text-[#46B3D9]">Påmelding 2026</p>
-            <p class="text-base font-bold md:text-lg">Påmeldingen er åpen. Sikre plass på Filtvet Feriekoloni.</p>
+            <p class="text-base font-bold md:text-lg">Fristen er passert. Søknader vurderes ved ledige plasser.</p>
         </div>
         <a href="/register/" class="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-5 py-3 font-bold text-[#0E2E58] transition-colors duration-200 hover:bg-slate-100">
             Meld på nå


### PR DESCRIPTION
## Summary
- Add a sticky bottom registration banner for the 2026 signup CTA
- Show the banner only after registration is open and the original CTA has scrolled past
- Update the front-page registration copy to say the deadline has passed and applications are considered if places are available
- Replace the original Christmas signup message with a compact yellow notice
- Link both CTAs consistently to /register/

## How it looks 📸
<img width="3852" height="2554" alt="CleanShot 2026-05-05 at 09 10 57@2x" src="https://github.com/user-attachments/assets/5559cb15-d0d4-4602-b85f-3751d542af02" />

<img width="3984" height="2686" alt="CleanShot 2026-05-05 at 09 14 56@2x" src="https://github.com/user-attachments/assets/53652938-eeb3-49c3-82f8-dcb9315aef63" />


## Verification
- Built with `deno task build`
- User verified sticky CTA behavior in browser on existing dev server