### PR TITLE
[codex] Add tournament roster builder

### DIFF
--- a/_components/navbar.vto
+++ b/_components/navbar.vto
@@ -10,6 +10,8 @@ links:
       url: /kontakt/
     - text: Støtte
       url: /grasrot/
+    - text: Turnering
+      url: /turnering/
 ---
 
 <nav class="mx-center mx-auto flex max-w-6xl flex-col py-5 sm:flex-row md:items-center">

--- a/_components/navbar.vto
+++ b/_components/navbar.vto
@@ -10,8 +10,6 @@ links:
       url: /kontakt/
     - text: Støtte
       url: /grasrot/
-    - text: Turnering
-      url: /turnering/
 ---
 
 <nav class="mx-center mx-auto flex max-w-6xl flex-col py-5 sm:flex-row md:items-center">

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -122,3 +122,709 @@ summary::-webkit-details-marker {
 
 @plugin "@tailwindcss/typography";
 @plugin "@tailwindcss/aspect-ratio";
+
+.tournament-app {
+  --tournament-border: #cbd5e1;
+  --tournament-muted: #475569;
+  --tournament-soft: #f8fafc;
+  --tournament-strong: #0f172a;
+  width: 100%;
+}
+
+.tournament-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.tournament-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.tournament-kicker {
+  margin-bottom: 0.4rem;
+  color: #2c72ac;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.tournament-header h1,
+.print-title h1 {
+  margin: 0;
+  color: var(--tournament-strong);
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.tournament-lead {
+  max-width: 48rem;
+  margin-top: 1rem;
+  color: var(--tournament-muted);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.tournament-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.tournament-panel,
+.tournament-output,
+.heat-card,
+.match-card,
+.unused-list {
+  border: 1px solid var(--tournament-border);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.tournament-panel {
+  padding: 1rem;
+}
+
+.tournament-panel h2,
+.output-toolbar h2,
+.section-heading h2,
+.unused-list h2,
+.empty-state h2 {
+  margin: 0;
+  color: var(--tournament-strong);
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.upload-box {
+  display: grid;
+  gap: 0.25rem;
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px dashed #94a3b8;
+  border-radius: 8px;
+  background: var(--tournament-soft);
+  cursor: pointer;
+}
+
+.upload-title {
+  font-weight: 700;
+}
+
+.upload-help,
+.section-heading span,
+.output-toolbar p,
+.tournament-note {
+  color: var(--tournament-muted);
+}
+
+.upload-box input {
+  margin-top: 0.5rem;
+}
+
+.manual-entry,
+.control-stack {
+  display: grid;
+  gap: 0.85rem;
+  margin-top: 1rem;
+}
+
+.manual-entry label,
+.control-stack label,
+.control-stack legend {
+  color: var(--tournament-strong);
+  font-weight: 700;
+}
+
+.manual-entry textarea,
+.control-stack input,
+.control-stack select {
+  width: 100%;
+  min-height: 2.75rem;
+  margin-top: 0.35rem;
+  border: 1px solid #94a3b8;
+  border-radius: 6px;
+  padding: 0.65rem 0.75rem;
+  background: #fff;
+  color: var(--tournament-strong);
+  font-size: 1rem;
+}
+
+.manual-entry textarea {
+  min-height: 8rem;
+  resize: vertical;
+}
+
+.summary-row,
+.button-row,
+.output-toolbar,
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.summary-row {
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.summary-row span {
+  flex: 1 1 7rem;
+  border: 1px solid var(--tournament-border);
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  background: var(--tournament-soft);
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.segmented-control {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem;
+  margin-top: 0.45rem;
+  border: 1px solid var(--tournament-border);
+  border-radius: 8px;
+  padding: 0.25rem;
+}
+
+.segmented-control input {
+  position: absolute;
+  opacity: 0;
+}
+
+.segmented-control span {
+  display: block;
+  min-height: 2.5rem;
+  border-radius: 6px;
+  padding: 0.65rem 0.5rem;
+  color: var(--tournament-muted);
+  text-align: center;
+  cursor: pointer;
+}
+
+.segmented-control input:checked + span {
+  background: #0f172a;
+  color: #fff;
+  font-weight: 700;
+}
+
+.button-row {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.tournament-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 2.75rem;
+  border: 1px solid #0f172a;
+  border-radius: 8px;
+  padding: 0.65rem 1rem;
+  background: #0f172a;
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.tournament-button-small {
+  min-height: 2.25rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.tournament-button-secondary {
+  border-color: var(--tournament-border);
+  background: #fff;
+  color: var(--tournament-strong);
+}
+
+.tournament-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.tournament-note {
+  margin-top: 0.85rem;
+  font-size: 0.9rem;
+}
+
+.tournament-output {
+  min-height: 18rem;
+  overflow: hidden;
+}
+
+.empty-state {
+  display: grid;
+  min-height: 18rem;
+  place-content: center;
+  padding: 2rem;
+  text-align: center;
+}
+
+.empty-state p {
+  max-width: 34rem;
+  color: var(--tournament-muted);
+}
+
+.print-title {
+  display: none;
+}
+
+.output-toolbar {
+  padding: 1rem;
+  border-bottom: 1px solid var(--tournament-border);
+  background: var(--tournament-soft);
+}
+
+.view-tabs {
+  display: flex;
+  gap: 0.25rem;
+  border: 1px solid var(--tournament-border);
+  border-radius: 8px;
+  padding: 0.25rem;
+  background: #fff;
+}
+
+.view-tabs button {
+  min-height: 2.3rem;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.45rem 0.75rem;
+  background: transparent;
+  color: var(--tournament-muted);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.view-tabs button.active {
+  background: #2c72ac;
+  color: #fff;
+}
+
+.warning-list {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1rem 0;
+}
+
+.warning-list p {
+  margin: 0;
+  border-left: 4px solid #f59e0b;
+  padding: 0.55rem 0.75rem;
+  background: #fffbeb;
+  color: #78350f;
+}
+
+.view-section {
+  display: none;
+}
+
+.view-section.active {
+  display: block;
+}
+
+.print-block {
+  padding: 1rem;
+}
+
+.section-heading {
+  align-items: baseline;
+  margin-bottom: 1rem;
+}
+
+.team-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.team-table,
+.heat-card table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.team-table th,
+.team-table td,
+.heat-card th,
+.heat-card td {
+  border: 1px solid var(--tournament-border);
+  padding: 0.65rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.team-table th,
+.heat-card th {
+  background: var(--tournament-soft);
+  font-weight: 700;
+}
+
+.team-table ol {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.team-table li {
+  margin-bottom: 0.2rem;
+}
+
+.team-table li span {
+  color: var(--tournament-muted);
+}
+
+.blank-cell {
+  min-width: 7rem;
+}
+
+.heat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 1rem;
+}
+
+.heat-card {
+  overflow: hidden;
+}
+
+.heat-card h3,
+.bracket-round h3 {
+  margin: 0;
+  padding: 0.8rem 0.9rem;
+  background: #0f172a;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.bracket {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 1rem;
+  align-items: start;
+}
+
+.bracket-round {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.match-card {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.75rem;
+}
+
+.match-card span {
+  color: var(--tournament-muted);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.match-card div,
+.match-card label {
+  min-height: 2.25rem;
+  border: 1px solid var(--tournament-border);
+  border-radius: 6px;
+  padding: 0.45rem 0.55rem;
+}
+
+.match-card label {
+  color: var(--tournament-muted);
+}
+
+.unused-list {
+  margin: 0 1rem 1rem;
+  padding: 1rem;
+}
+
+.unused-list p {
+  margin: 0.5rem 0 0;
+  color: var(--tournament-muted);
+}
+
+@media (max-width: 760px) {
+  .tournament-app {
+    padding-top: 1rem;
+    padding-bottom: 2rem;
+  }
+
+  .tournament-header,
+  .tournament-grid,
+  .output-toolbar,
+  .section-heading {
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .tournament-header h1 {
+    font-size: 2rem;
+    line-height: 1.08;
+  }
+
+  .tournament-lead {
+    margin-top: 0.75rem;
+    font-size: 0.95rem;
+    line-height: 1.55;
+  }
+
+  .tournament-panel,
+  .print-block {
+    padding: 0.85rem;
+  }
+
+  .tournament-header-actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .tournament-header-actions .tournament-button {
+    width: 100%;
+  }
+
+  .tournament-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .segmented-control {
+    grid-template-columns: 1fr;
+  }
+
+  .segmented-control span {
+    min-height: 2.65rem;
+  }
+
+  .button-row {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .button-row .tournament-button {
+    width: 100%;
+  }
+
+  .output-toolbar {
+    padding: 0.85rem;
+  }
+
+  .view-tabs {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .view-tabs button {
+    flex: 1;
+    min-width: 5rem;
+    white-space: nowrap;
+  }
+
+  .section-heading {
+    align-items: start;
+  }
+
+  .section-heading span {
+    font-size: 0.9rem;
+  }
+
+  .heat-grid,
+  .bracket {
+    grid-template-columns: 1fr;
+  }
+
+  .unused-list {
+    margin: 0 0.85rem 0.85rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .team-table,
+  .team-table thead,
+  .team-table tbody,
+  .team-table tr,
+  .team-table th,
+  .team-table td {
+    display: block;
+  }
+
+  .team-table thead {
+    display: none;
+  }
+
+  .team-table tbody {
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .team-table tr {
+    border: 1px solid var(--tournament-border);
+    border-radius: 8px;
+    overflow: hidden;
+    background: #fff;
+  }
+
+  .team-table td {
+    display: grid;
+    grid-template-columns: 5.75rem minmax(0, 1fr);
+    gap: 0.75rem;
+    min-height: 2.6rem;
+    border-width: 0 0 1px;
+    padding: 0.65rem 0.75rem;
+  }
+
+  .team-table td:last-child {
+    border-bottom: 0;
+  }
+
+  .team-table td::before {
+    content: attr(data-label);
+    color: var(--tournament-muted);
+    font-weight: 700;
+  }
+
+  .team-table ol {
+    padding-left: 1rem;
+  }
+
+  .blank-cell {
+    min-width: 0;
+  }
+
+  .heat-card table,
+  .heat-card thead,
+  .heat-card tbody,
+  .heat-card tr,
+  .heat-card th,
+  .heat-card td {
+    display: block;
+  }
+
+  .heat-card thead {
+    display: none;
+  }
+
+  .heat-card tbody {
+    display: grid;
+  }
+
+  .heat-card tr {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(4.5rem, 0.8fr) minmax(4.5rem, 0.8fr);
+    border-bottom: 1px solid var(--tournament-border);
+  }
+
+  .heat-card tr:last-child {
+    border-bottom: 0;
+  }
+
+  .heat-card td {
+    min-height: 2.8rem;
+    border: 0;
+    border-right: 1px solid var(--tournament-border);
+    padding: 0.55rem;
+  }
+
+  .heat-card td:last-child {
+    border-right: 0;
+  }
+
+  .heat-card td::before {
+    display: block;
+    margin-bottom: 0.2rem;
+    content: attr(data-label);
+    color: var(--tournament-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+  }
+
+  .match-card {
+    padding: 0.65rem;
+  }
+
+  .warning-list {
+    padding: 0.85rem 0.85rem 0;
+  }
+
+  .empty-state {
+    min-height: 14rem;
+    padding: 1.25rem;
+  }
+}
+
+@media print {
+  body {
+    background: #fff;
+  }
+
+  main {
+    padding: 0 !important;
+    background: #fff !important;
+  }
+
+  nav,
+  .print-hidden {
+    display: none !important;
+  }
+
+  .tournament-app {
+    max-width: none;
+    padding: 0;
+  }
+
+  .tournament-output {
+    border: 0;
+  }
+
+  .print-title {
+    display: block;
+    margin-bottom: 1rem;
+  }
+
+  .print-title p {
+    margin: 0 0 0.25rem;
+    color: #475569;
+  }
+
+  .view-section,
+  .view-section.active {
+    display: block;
+    break-inside: avoid;
+  }
+
+  .print-block,
+  .unused-list,
+  .warning-list {
+    padding: 0;
+    margin: 0 0 1rem;
+  }
+
+  .heat-grid,
+  .bracket {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .team-table th,
+  .team-table td,
+  .heat-card th,
+  .heat-card td {
+    padding: 0.45rem;
+  }
+}

--- a/lek.vto
+++ b/lek.vto
@@ -1,0 +1,27 @@
+---
+layout: base.vto
+title: Lek | Trefoldighet Feriekoloni
+---
+
+<section class="mx-auto max-w-4xl px-4 pb-16 pt-8 text-slate-950">
+    <div class="mb-8">
+        <p class="mb-2 text-sm font-bold uppercase blue-primary">Lek</p>
+        <h1 class="text-4xl font-semibold leading-tight">Verktøy for lek og turnering</h1>
+        <p class="mt-4 max-w-2xl text-lg text-slate-600">
+            En liten intern snarvei til praktiske verktøy vi kan bruke på kolonien.
+        </p>
+    </div>
+
+    <div class="grid gap-4 sm:grid-cols-2">
+        <a
+            class="block rounded-lg border border-slate-300 bg-white p-5 shadow-sm transition hover:border-slate-500 hover:shadow-md"
+            href="/turnering/"
+        >
+            <h2 class="text-xl font-bold">Lagoppsett og kampplan</h2>
+            <p class="mt-2 text-slate-600">
+                Last opp deltakere, lag turneringslag, stokke på nytt, og skriv ut heats og finaler.
+            </p>
+            <span class="mt-4 inline-block font-bold blue-primary">Åpne turnering →</span>
+        </a>
+    </div>
+</section>

--- a/turnering.vto
+++ b/turnering.vto
@@ -1,0 +1,756 @@
+---
+layout: base.vto
+title: Turnering | Trefoldighet Feriekoloni
+---
+
+<section
+  class="tournament-app mx-auto max-w-7xl px-2 pb-16 pt-8 text-slate-950 sm:px-4"
+>
+  <div class="tournament-header">
+    <div>
+      <p class="tournament-kicker">Turneringsverktøy</p>
+      <h1>Lagoppsett og kampplan</h1>
+      <p class="tournament-lead">
+        Last opp en CSV med fornavn og alder, velg turneringstype, og skriv ut
+        lag, heats og finaler. Alt skjer lokalt i nettleseren.
+      </p>
+    </div>
+    <div class="tournament-header-actions print-hidden">
+      <button
+        class="tournament-button tournament-button-secondary tournament-button-small"
+        id="demo-button"
+        type="button"
+      >
+        Demo
+      </button>
+      <button
+        class="tournament-button tournament-button-secondary"
+        id="print-button"
+        type="button"
+      >
+        <span aria-hidden="true">⎙</span>
+        Skriv ut
+      </button>
+    </div>
+  </div>
+
+  <div class="tournament-grid print-hidden">
+    <section class="tournament-panel">
+      <h2>1. Deltakere</h2>
+      <label class="upload-box" for="csv-file">
+        <span class="upload-title">Velg CSV-fil</span>
+        <span class="upload-help"
+        >Kolonner: fornavn og alder. Overskrift er valgfritt.</span>
+        <input id="csv-file" type="file" accept=".csv, text/csv" />
+      </label>
+      <div class="manual-entry">
+        <label for="manual-csv">Eller lim inn CSV</label>
+        <textarea
+          id="manual-csv"
+          rows="6"
+          placeholder="Navn,Alder&#10;Anna,11&#10;Marius,35"
+        ></textarea>
+        <button
+          class="tournament-button tournament-button-secondary"
+          id="load-sample-button"
+          type="button"
+        >
+          Eksempeldata
+        </button>
+      </div>
+      <div class="summary-row" id="people-summary">
+        <span>0 barn</span>
+        <span>0 voksne</span>
+        <span>0 totalt</span>
+      </div>
+    </section>
+
+    <section class="tournament-panel">
+      <h2>2. Oppsett</h2>
+      <div class="control-stack">
+        <fieldset>
+          <legend>Turneringstype</legend>
+          <div
+            class="segmented-control"
+            role="radiogroup"
+            aria-label="Turneringstype"
+          >
+            <label>
+              <input type="radio" name="tournament-type" value="kids" checked />
+              <span>Barn</span>
+            </label>
+            <label>
+              <input type="radio" name="tournament-type" value="adults" />
+              <span>Voksne</span>
+            </label>
+            <label>
+              <input type="radio" name="tournament-type" value="mixed" />
+              <span>Blandet</span>
+            </label>
+          </div>
+        </fieldset>
+
+        <label>
+          Spillere per lag
+          <input
+            id="players-per-team"
+            type="number"
+            min="2"
+            max="12"
+            value="5"
+          />
+        </label>
+
+        <label>
+          Voksen fra alder
+          <input id="adult-age" type="number" min="13" max="99" value="18" />
+        </label>
+
+        <label>
+          Lagnavn
+          <select id="team-name-style">
+            <option value="letters">Lag A, B, C</option>
+            <option value="numbers">Lag 1, 2, 3</option>
+            <option value="colors">Farger</option>
+          </select>
+        </label>
+
+        <label>
+          Maks lag per heat
+          <input id="teams-per-heat" type="number" min="2" max="6" value="4" />
+        </label>
+      </div>
+      <div class="button-row">
+        <button class="tournament-button" id="generate-button" type="button">
+          Generer
+        </button>
+        <button
+          class="tournament-button tournament-button-secondary"
+          id="reshuffle-button"
+          type="button"
+          disabled
+        >
+          Stokk på nytt
+        </button>
+      </div>
+      <p class="tournament-note" id="setup-note">
+        Blandet turnering lager lag med barn først og bruker maks én voksen som
+        lagleder per lag.
+      </p>
+    </section>
+  </div>
+
+  <section class="tournament-output" id="output" aria-live="polite">
+    <div class="empty-state">
+      <h2>Klar for lagoppsett</h2>
+      <p>
+        Last opp eller lim inn CSV-data, juster innstillingene, og trykk
+        Generer.
+      </p>
+    </div>
+  </section>
+</section>
+
+<script>
+  (function () {
+    const state = {
+      people: [],
+      teams: [],
+      heats: [],
+      unused: [],
+      warnings: [],
+    };
+
+    const sampleCsv = `Navn,Alder
+Anna,9
+Emil,10
+Sofia,11
+Jonas,12
+Maja,10
+Oliver,9
+Nora,13
+Lucas,11
+Thea,8
+William,12
+Leah,10
+Henrik,13
+Oda,9
+Isak,11
+Ingrid,12
+Mathias,10
+Kari,34
+Thomas,41
+Mina,27
+Eirik,22
+Lars,48
+Silje,31`;
+
+    const elements = {
+      file: document.getElementById("csv-file"),
+      demo: document.getElementById("demo-button"),
+      manualCsv: document.getElementById("manual-csv"),
+      loadSample: document.getElementById("load-sample-button"),
+      peopleSummary: document.getElementById("people-summary"),
+      playersPerTeam: document.getElementById("players-per-team"),
+      adultAge: document.getElementById("adult-age"),
+      teamNameStyle: document.getElementById("team-name-style"),
+      teamsPerHeat: document.getElementById("teams-per-heat"),
+      generate: document.getElementById("generate-button"),
+      reshuffle: document.getElementById("reshuffle-button"),
+      output: document.getElementById("output"),
+      print: document.getElementById("print-button"),
+    };
+
+    elements.file.addEventListener("change", handleFileUpload);
+    elements.manualCsv.addEventListener(
+      "input",
+      () => loadPeople(elements.manualCsv.value),
+    );
+    elements.demo.addEventListener("click", () => useDemoData(true));
+    elements.loadSample.addEventListener("click", () => useDemoData(false));
+    elements.generate.addEventListener("click", generateTournament);
+    elements.reshuffle.addEventListener("click", generateTournament);
+    elements.print.addEventListener("click", () => window.print());
+    elements.adultAge.addEventListener("change", () => {
+      if (elements.manualCsv.value.trim()) loadPeople(elements.manualCsv.value);
+    });
+
+    function handleFileUpload(event) {
+      const file = event.target.files && event.target.files[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        const text = String(reader.result || "");
+        elements.manualCsv.value = text;
+        loadPeople(text);
+      };
+      reader.readAsText(file);
+    }
+
+    function useDemoData(shouldGenerate) {
+      const mixedOption = document.querySelector(
+        'input[name="tournament-type"][value="mixed"]',
+      );
+      elements.manualCsv.value = sampleCsv;
+      loadPeople(sampleCsv);
+
+      if (mixedOption) mixedOption.checked = true;
+      if (shouldGenerate) generateTournament();
+    }
+
+    function loadPeople(csvText) {
+      const adultAge = getAdultAge();
+      state.people = parseCsv(csvText).map((person, index) => ({
+        ...person,
+        id: `${person.name}-${person.age}-${index}`,
+        type: person.age >= adultAge ? "adult" : "child",
+      }));
+      updateSummary();
+    }
+
+    function parseCsv(text) {
+      const rows = text
+        .split(/\r?\n/)
+        .map((line) => splitCsvLine(line).map((cell) => cell.trim()))
+        .filter((row) => row.some(Boolean));
+
+      if (rows.length === 0) return [];
+
+      const firstRow = rows[0].map((cell) => cell.toLowerCase());
+      const hasHeader =
+        firstRow.some((cell) =>
+          ["navn", "name", "first name", "fornavn"].includes(cell)
+        ) ||
+        firstRow.some((cell) => ["alder", "age"].includes(cell));
+
+      const header = hasHeader ? firstRow : [];
+      const nameIndex = header.findIndex((cell) =>
+        ["navn", "name", "first name", "fornavn"].includes(cell)
+      );
+      const ageIndex = header.findIndex((cell) =>
+        ["alder", "age"].includes(cell)
+      );
+      const dataRows = hasHeader ? rows.slice(1) : rows;
+
+      return dataRows.map((row) => {
+        const name = row[nameIndex >= 0 ? nameIndex : 0] || "";
+        const age = Number.parseInt(row[ageIndex >= 0 ? ageIndex : 1], 10);
+        return { name, age };
+      }).filter((person) => person.name && Number.isFinite(person.age));
+    }
+
+    function splitCsvLine(line) {
+      const cells = [];
+      let cell = "";
+      let quoted = false;
+
+      for (let index = 0; index < line.length; index += 1) {
+        const char = line[index];
+        const next = line[index + 1];
+
+        if (char === '"' && quoted && next === '"') {
+          cell += '"';
+          index += 1;
+        } else if (char === '"') {
+          quoted = !quoted;
+        } else if (char === "," && !quoted) {
+          cells.push(cell);
+          cell = "";
+        } else {
+          cell += char;
+        }
+      }
+
+      cells.push(cell);
+      return cells;
+    }
+
+    function generateTournament() {
+      if (state.people.length === 0) {
+        renderEmpty(
+          "Ingen deltakere",
+          "Last opp eller lim inn en CSV med navn og alder først.",
+        );
+        return;
+      }
+
+      const type = getTournamentType();
+      const playersPerTeam = getPlayersPerTeam();
+      const teamsPerHeat = getTeamsPerHeat();
+      const children = shuffle(
+        state.people.filter((person) => person.type === "child"),
+      );
+      const adults = shuffle(
+        state.people.filter((person) => person.type === "adult"),
+      );
+
+      state.warnings = [];
+      if (type === "mixed") {
+        state.teams = buildMixedTeams(children, adults, playersPerTeam);
+      } else {
+        const pool = type === "kids" ? children : adults;
+        state.unused = type === "kids" ? adults : children;
+        state.teams = buildEvenTeams(pool, playersPerTeam);
+        if (pool.length === 0) {
+          state.warnings.push(
+            type === "kids"
+              ? "Ingen barn funnet i CSV-en."
+              : "Ingen voksne funnet i CSV-en.",
+          );
+        }
+      }
+
+      state.heats = buildHeats(state.teams, teamsPerHeat);
+      elements.reshuffle.disabled = state.teams.length === 0;
+      renderOutput(type, playersPerTeam);
+    }
+
+    function buildEvenTeams(players, playersPerTeam) {
+      state.unused = [];
+      if (players.length === 0) return [];
+
+      const teamCount = Math.max(1, Math.ceil(players.length / playersPerTeam));
+      const teams = createEmptyTeams(teamCount);
+      players.forEach((player, index) => {
+        teams[index % teamCount].players.push(player);
+      });
+      return teams;
+    }
+
+    function buildMixedTeams(children, adults, playersPerTeam) {
+      state.unused = [];
+      if (children.length === 0) {
+        state.unused = adults;
+        state.warnings.push(
+          "Ingen barn funnet. Blandet turnering prioriterer barn, så ingen lag ble laget.",
+        );
+        return [];
+      }
+
+      const kidsPerTeam = Math.max(1, playersPerTeam - 1);
+      const teamCount = Math.max(1, Math.ceil(children.length / kidsPerTeam));
+      const teams = createEmptyTeams(teamCount);
+
+      teams.forEach((team, index) => {
+        if (adults[index]) {
+          team.lead = adults[index];
+          team.players.push(adults[index]);
+        }
+      });
+
+      children.forEach((child, index) => {
+        teams[index % teamCount].players.push(child);
+      });
+
+      state.unused = adults.slice(teamCount);
+      if (adults.length < teamCount) {
+        state.warnings.push(
+          `${teamCount - adults.length} lag mangler voksen lagleder.`,
+        );
+      }
+      if (state.unused.length > 0) {
+        state.warnings.push(
+          `${state.unused.length} voksne ble satt på venteliste for å prioritere barna.`,
+        );
+      }
+
+      return teams;
+    }
+
+    function createEmptyTeams(count) {
+      return Array.from({ length: count }, (_, index) => ({
+        id: index + 1,
+        name: getTeamName(index),
+        players: [],
+        lead: null,
+      }));
+    }
+
+    function buildHeats(teams, teamsPerHeat) {
+      if (teams.length === 0) return [];
+      const heatCount = Math.max(1, Math.ceil(teams.length / teamsPerHeat));
+      const heats = Array.from({ length: heatCount }, (_, index) => ({
+        name: `Heat ${String.fromCharCode(65 + index)}`,
+        teams: [],
+      }));
+
+      teams.forEach((team, index) => {
+        heats[index % heatCount].teams.push(team);
+      });
+      return heats;
+    }
+
+    function renderOutput(type, playersPerTeam) {
+      if (state.teams.length === 0) {
+        renderEmpty(
+          "Ingen lag laget",
+          state.warnings[0] || "Endre innstillingene og prøv igjen.",
+        );
+        return;
+      }
+
+      const teamCount = state.teams.length;
+      const peopleInTeams = state.teams.reduce(
+        (sum, team) => sum + team.players.length,
+        0,
+      );
+      const modeText = {
+        kids: "Barneturnering",
+        adults: "Voksenturnering",
+        mixed: "Blandet turnering",
+      }[type];
+
+      elements.output.innerHTML = `
+            <div class="print-title">
+                <p>Filtvet Feriekoloni</p>
+                <h1>${escapeHtml(modeText)}</h1>
+            </div>
+            <div class="output-toolbar print-hidden">
+                <div>
+                    <h2>${escapeHtml(modeText)}</h2>
+                    <p>${teamCount} lag, ${peopleInTeams} spillere i lag, ${playersPerTeam} spillere per lag.</p>
+                </div>
+                <div class="view-tabs" role="tablist" aria-label="Visning">
+                    <button class="active" data-view="teams" type="button">Lag</button>
+                    <button data-view="heats" type="button">Heats</button>
+                    <button data-view="finals" type="button">Finaler</button>
+                </div>
+            </div>
+            ${renderWarnings()}
+            <div class="view-section active" data-section="teams">${renderTeamsTable()}</div>
+            <div class="view-section" data-section="heats">${renderHeats()}</div>
+            <div class="view-section" data-section="finals">${renderFinals()}</div>
+            ${renderUnused()}
+        `;
+
+      elements.output.querySelectorAll(".view-tabs button").forEach(
+        (button) => {
+          button.addEventListener(
+            "click",
+            () => switchView(button.dataset.view),
+          );
+        },
+      );
+    }
+
+    function renderTeamsTable() {
+      return `
+            <section class="print-block">
+                <div class="section-heading">
+                    <h2>Lagliste</h2>
+                    <span>Fyll inn lagnavn eller draktfarge før kampstart.</span>
+                </div>
+                <div class="team-table-wrap">
+                    <table class="team-table">
+                        <thead>
+                            <tr>
+                                <th>Lag</th>
+                                <th>Lagnavn</th>
+                                <th>Lagleder</th>
+                                <th>Spillere</th>
+                                <th>Notat</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            ${
+        state.teams.map((team) => `
+                                <tr>
+                                    <td data-label="Lag">${escapeHtml(team.name)}</td>
+                                    <td class="blank-cell" data-label="Lagnavn"></td>
+                                    <td data-label="Lagleder">${
+          team.lead ? escapeHtml(team.lead.name) : ""
+        }</td>
+                                    <td data-label="Spillere">
+                                        <ol>
+                                            ${
+          team.players.map((player) => `
+                                                <li>${
+            escapeHtml(player.name)
+          } <span>${player.age}</span></li>
+                                            `).join("")
+        }
+                                        </ol>
+                                    </td>
+                                    <td class="blank-cell" data-label="Notat"></td>
+                                </tr>
+                            `).join("")
+      }
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        `;
+    }
+
+    function renderHeats() {
+      return `
+            <section class="print-block">
+                <div class="section-heading">
+                    <h2>Heats</h2>
+                    <span>Bruk plass-kolonnen til å velge hvem som går videre.</span>
+                </div>
+                <div class="heat-grid">
+                    ${
+        state.heats.map((heat) => `
+                        <article class="heat-card">
+                            <h3>${escapeHtml(heat.name)}</h3>
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>Lag</th>
+                                        <th>Poeng</th>
+                                        <th>Plass</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    ${
+          heat.teams.map((team) => `
+                                        <tr>
+                                            <td data-label="Lag">${escapeHtml(team.name)}</td>
+                                            <td data-label="Poeng"></td>
+                                            <td data-label="Plass"></td>
+                                        </tr>
+                                    `).join("")
+        }
+                                </tbody>
+                            </table>
+                        </article>
+                    `).join("")
+      }
+                </div>
+            </section>
+        `;
+    }
+
+    function renderFinals() {
+      const slots = state.heats.map((heat) => `Vinner ${heat.name}`);
+      const bracketSlots = nextPowerOfTwo(Math.max(2, slots.length));
+      while (slots.length < bracketSlots) slots.push("Ledig");
+      const rounds = buildBracketRounds(slots);
+
+      return `
+            <section class="print-block">
+                <div class="section-heading">
+                    <h2>Finaler</h2>
+                    <span>Tomrommene fylles ut etter heatene.</span>
+                </div>
+                <div class="bracket">
+                    ${
+        rounds.map((round, index) => `
+                        <div class="bracket-round">
+                            <h3>${
+          escapeHtml(getRoundName(rounds.length, index))
+        }</h3>
+                            ${
+          round.map((match, matchIndex) => `
+                                <div class="match-card">
+                                    <span>Kamp ${matchIndex + 1}</span>
+                                    <div>${escapeHtml(match[0] || "")}</div>
+                                    <div>${escapeHtml(match[1] || "")}</div>
+                                    <label>Vinner</label>
+                                </div>
+                            `).join("")
+        }
+                        </div>
+                    `).join("")
+      }
+                </div>
+            </section>
+        `;
+    }
+
+    function buildBracketRounds(initialSlots) {
+      const rounds = [];
+      let current = initialSlots;
+
+      while (current.length >= 2) {
+        const matches = [];
+        for (let index = 0; index < current.length; index += 2) {
+          matches.push([current[index], current[index + 1]]);
+        }
+        rounds.push(matches);
+        if (matches.length === 1) break;
+        current = matches.map((_, index) => `Vinner kamp ${index + 1}`);
+      }
+
+      return rounds;
+    }
+
+    function renderWarnings() {
+      if (state.warnings.length === 0) return "";
+      return `
+            <div class="warning-list">
+                ${
+        state.warnings.map((warning) => `<p>${escapeHtml(warning)}</p>`).join(
+          "",
+        )
+      }
+            </div>
+        `;
+    }
+
+    function renderUnused() {
+      if (state.unused.length === 0) return "";
+      return `
+            <section class="unused-list">
+                <h2>Venteliste / ikke brukt</h2>
+                <p>${
+        state.unused.map((person) =>
+          `${escapeHtml(person.name)} (${person.age})`
+        ).join(", ")
+      }</p>
+            </section>
+        `;
+    }
+
+    function renderEmpty(title, text) {
+      elements.output.innerHTML = `
+            <div class="empty-state">
+                <h2>${escapeHtml(title)}</h2>
+                <p>${escapeHtml(text)}</p>
+            </div>
+        `;
+    }
+
+    function switchView(view) {
+      elements.output.querySelectorAll(".view-tabs button").forEach(
+        (button) => {
+          button.classList.toggle("active", button.dataset.view === view);
+        },
+      );
+      elements.output.querySelectorAll(".view-section").forEach((section) => {
+        section.classList.toggle("active", section.dataset.section === view);
+      });
+    }
+
+    function updateSummary() {
+      const children =
+        state.people.filter((person) => person.type === "child").length;
+      const adults =
+        state.people.filter((person) => person.type === "adult").length;
+      elements.peopleSummary.innerHTML = `
+            <span>${children} barn</span>
+            <span>${adults} voksne</span>
+            <span>${state.people.length} totalt</span>
+        `;
+    }
+
+    function getTournamentType() {
+      return document.querySelector('input[name="tournament-type"]:checked')
+        .value;
+    }
+
+    function getPlayersPerTeam() {
+      return clampNumber(elements.playersPerTeam.value, 2, 12, 5);
+    }
+
+    function getAdultAge() {
+      return clampNumber(elements.adultAge.value, 13, 99, 18);
+    }
+
+    function getTeamsPerHeat() {
+      return clampNumber(elements.teamsPerHeat.value, 2, 6, 4);
+    }
+
+    function clampNumber(value, min, max, fallback) {
+      const number = Number.parseInt(value, 10);
+      if (!Number.isFinite(number)) return fallback;
+      return Math.min(max, Math.max(min, number));
+    }
+
+    function getTeamName(index) {
+      const style = elements.teamNameStyle.value;
+      const colors = [
+        "Rød",
+        "Blå",
+        "Grønn",
+        "Gul",
+        "Hvit",
+        "Svart",
+        "Oransje",
+        "Lilla",
+        "Turkis",
+        "Rosa",
+      ];
+      if (style === "numbers") return `Lag ${index + 1}`;
+      if (style === "colors") {
+        return colors[index] ? `Lag ${colors[index]}` : `Lag ${index + 1}`;
+      }
+      return `Lag ${String.fromCharCode(65 + index)}`;
+    }
+
+    function getRoundName(totalRounds, index) {
+      if (index === totalRounds - 1) return "Finale";
+      if (index === totalRounds - 2) return "Semifinaler";
+      if (index === totalRounds - 3) return "Kvartfinaler";
+      return `Runde ${index + 1}`;
+    }
+
+    function nextPowerOfTwo(number) {
+      let power = 1;
+      while (power < number) power *= 2;
+      return power;
+    }
+
+    function shuffle(items) {
+      const copy = [...items];
+      for (let index = copy.length - 1; index > 0; index -= 1) {
+        const swapIndex = Math.floor(Math.random() * (index + 1));
+        [copy[index], copy[swapIndex]] = [copy[swapIndex], copy[index]];
+      }
+      return copy;
+    }
+
+    function escapeHtml(value) {
+      return String(value).replace(/[&<>"']/g, (char) =>
+        ({
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          '"': "&quot;",
+          "'": "&#039;",
+        })[char]);
+    }
+  })();
+</script>


### PR DESCRIPTION
## What changed

Adds a client-side tournament roster builder at `/turnering/` for camp sports tournaments.

- Adds CSV upload/paste for participants with first name and age
- Supports kids-only, adults-only, and mixed tournaments
- Builds teams with configurable players per team and one adult lead per mixed team
- Prioritizes children in mixed tournaments and lists unused adults separately
- Adds reshuffle and demo-data flows
- Renders printable team rosters, heats, and empty finals bracket slots
- Improves the mobile layout with stacked roster cards, touch-sized controls, and single-column brackets
- Links the tool from the site navbar

## Impact

Camp staff can generate, reshuffle, view, and print tournament plans entirely in the browser without sending participant data to a server.

## Validation

- `deno task build`
- `deno lint`
- Demo-generation runtime check
- Served `/turnering/` route check
